### PR TITLE
Fix for Fo_r_ster typo

### DIFF
--- a/posts/extensions/scripts/_posts/2012-11-14-autofocus-system.md
+++ b/posts/extensions/scripts/_posts/2012-11-14-autofocus-system.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Autofocus System
-description: Use this script to implement a version of [Mark Foster's](http://markforster.squarespace.com/autofocus-system/) autofocus time management system.
+description: Use this script to implement a version of [Mark Forster's](http://markforster.squarespace.com/autofocus-system/) Autofocus time management system.
 ---
 
 {{page.description}}


### PR DESCRIPTION
Fixed on Autofocus script page/description. Also capitalized Autofocus system.
