### PR TITLE
Fix FT script page gists URLs

### DIFF
--- a/posts/extensions/scripts/_posts/2012-11-01-syntax-examples-script.md
+++ b/posts/extensions/scripts/_posts/2012-11-01-syntax-examples-script.md
@@ -9,4 +9,4 @@ description: Use these scripts to learn FoldingText's different scripting syntax
 These scripts don't provide any useful functionality, but they do show all the different ways that you can script FoldingText. They serve as a good reference when creating your own scripts.
 
 - [**View Script**](https://gist.github.com/4074142)
-- [**Download Script**](https://gist.github.com/gists/4074142/download)
+- [**Download Script**](https://gist.github.com/4074142/download)

--- a/posts/extensions/scripts/_posts/2012-11-12-archive-done-script.md
+++ b/posts/extensions/scripts/_posts/2012-11-12-archive-done-script.md
@@ -19,5 +19,5 @@ When you are ready to archive a `@done` item place your text cursor on the items
 
 You can archive multiple items by selecting them all before running the script.
 
-- [**View Script**](https://gist.github.com/gists/4061766/)
-- [**Download Script**](https://gist.github.com/gists/4061766/download)
+- [**View Script**](https://gist.github.com/4061766/)
+- [**Download Script**](https://gist.github.com/4061766/download)

--- a/posts/extensions/scripts/_posts/2012-11-14-autofocus-system-script.md
+++ b/posts/extensions/scripts/_posts/2012-11-14-autofocus-system-script.md
@@ -25,5 +25,5 @@ In this implementation an `Autofocus.todo` heading is created for each page. Use
 
 3. Instead of manually re-entering items that you are not finished with, place your text cursor on the items line, and run the linked to "Re-Enter" script. That will move a copy of the item to the end of your list. And it will automatically create "Autofocus.todo" headings as needed.
 
-- [**View Script**](https://gist.github.com/gists/4075021/)
-- [**Download Script**](https://gist.github.com/gists/4075021/download)
+- [**View Script**](https://gist.github.com/4075021/)
+- [**Download Script**](https://gist.github.com/4075021/download)

--- a/posts/extensions/scripts/_posts/2012-11-16-make-header-script.md
+++ b/posts/extensions/scripts/_posts/2012-11-16-make-header-script.md
@@ -10,5 +10,5 @@ This script makes it easy to quickly mark a line as a heading. It automates movi
 
 This script is most useful if you [assign a keyboard shortcut](./using_scripts/) to it, then you can make a header in a single keystroke.
 
-- [**View Script**](https://gist.github.com/gists/4087248)
-- [**Download Script**](https://gist.github.com/gists/4087248/download)
+- [**View Script**](https://gist.github.com/4087248)
+- [**Download Script**](https://gist.github.com/4087248/download)


### PR DESCRIPTION
Github's updates to gists also changed their standard URL. They no longer use `.../gists/...` as part of the path, which breaks any links using it (404 page, not redirected). This pull request is just an edit to script page links when a script is hosted as a GitHub gist.
