### PR TITLE
Fix for minor typo on "Export to OPML or Omni"

### DIFF
--- a/posts/extensions/scripts/_posts/2013-01-09-export-to-OPML-or-Omni-script.md
+++ b/posts/extensions/scripts/_posts/2013-01-09-export-to-OPML-or-Omni-script.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Export to OPTML or Omni Script
+title: Export to OPML or Omni – Script
 description: Use this script to export to OPML or Omni app formats.
 ---
 


### PR DESCRIPTION
The title for the script page had an extra character and was missing the "–" before "Script".
