### PR TITLE
Fix download link on OPML/Omni Export script page

### DIFF
--- a/posts/extensions/scripts/_posts/2013-01-09-export-to-OPML-or-Omni-script.md
+++ b/posts/extensions/scripts/_posts/2013-01-09-export-to-OPML-or-Omni-script.md
@@ -11,4 +11,4 @@ This script exports the selected line in FoldingText, with all of its descendant
 The list of export choices offered by the script will depend on which, if any, Omni apps are installed, and may include OmniOutliner, OmniFocus, and OmniGraffle as well as the default OPML. If OPML is chosen, a File Save dialog will appear. If an Omni app is chosen, the application will be launched, if necessary, and the output will take the form of a new (unsaved) Omni app document.
 
 - [**View Script**](https://github.com/RobTrew/tree-tools/tree/master/FoldingText%20scripts/Import%20Export)
-- [**Download Script**](https://github.com/RobTrew/tree-tools/blob/master/FoldingText%20scripts/Import%20Export/FT2OMNI-018.scptd.zip?raw=true)
+- [**Download Script**](https://github.com/RobTrew/tree-tools/blob/master/FoldingText%20scripts/Import%20Export/FT2OMNI.scptd.zip?raw=true)


### PR DESCRIPTION
Removed version number from download path for zip to match source.
